### PR TITLE
Security Headers updates

### DIFF
--- a/app/controllers/headlines/categories_controller.rb
+++ b/app/controllers/headlines/categories_controller.rb
@@ -72,9 +72,8 @@ module Headlines
     def category_domains(category, limit: 25)
       filtered_domains(
         DomainsInCategory.new(category: category)
-          .includes(:scans)
-          .joins(:scans)
-          .where("headlines_scans.id = (SELECT MAX(headlines_scans.id) FROM headlines_scans WHERE headlines_scans.domain_id = headlines_domains.id)")
+          .includes(:last_scan)
+          .joins(:last_scan)
           .offset(offset)
           .order(:rank)
           .limit(limit)

--- a/app/controllers/headlines/categories_controller.rb
+++ b/app/controllers/headlines/categories_controller.rb
@@ -72,10 +72,11 @@ module Headlines
     def category_domains(category, limit: 25)
       filtered_domains(
         DomainsInCategory.new(category: category)
-          .includes(:scan)
-          .joins(:scan)
+          .includes(:scans)
+          .joins(:scans)
+          .where("headlines_scans.id = (SELECT MAX(headlines_scans.id) FROM headlines_scans WHERE headlines_scans.domain_id = headlines_domains.id)")
           .offset(offset)
-          .order("rank")
+          .order(:rank)
           .limit(limit)
       )
     end

--- a/app/controllers/headlines/domains_controller.rb
+++ b/app/controllers/headlines/domains_controller.rb
@@ -22,28 +22,16 @@ module Headlines
         domain,
         DomainScanSerializer,
         root: false,
-        category: category,
-        domains: category_domains(category)
+        category: category
       )
     end
 
     def category
-      @category ||= CategoryWithParents.new(Category.find(params[:category_id]))
-    end
-
-    def category_domains(category)
-      DomainsInCategory.new(category: category)
-        .includes(:scan)
-        .joins(:scan)
-        .order("rank DESC")
-        .limit(100)
+      @category ||= CategoryWithParents.new(Headlines::Category.find(params[:category_id]))
     end
 
     def domain
-      DomainsInCategory.new(category: category)
-        .includes(:scan)
-        .order("rank DESC")
-        .find(params[:id])
+      DomainsInCategory.new(category: category).find(params[:id])
     end
   end
 end

--- a/app/controllers/headlines/scans_controller.rb
+++ b/app/controllers/headlines/scans_controller.rb
@@ -27,13 +27,7 @@ module Headlines
     def scan_results
       return {} unless result.success?
 
-      {
-        score: result.score,
-        http_score: result.http_score,
-        csp_score: result.csp_score,
-        http_headers: result.params[0..-2],
-        csp_header: result.params.last
-      }
+      result[:params].slice(:score, :http_score, :csp_score, :http_headers, :csp_header)
     end
 
     def result

--- a/app/interactors/headlines/generate_results.rb
+++ b/app/interactors/headlines/generate_results.rb
@@ -9,7 +9,7 @@ module Headlines
       context.params = { headers: headers,
                          http_headers: headers[0..-2],
                          csp_header: headers.last,
-                         scan_results: scan_results,
+                         results: scan_results,
                          score: overall_score,
                          http_score: http_score,
                          csp_score: csp_score }

--- a/app/models/headlines/domain.rb
+++ b/app/models/headlines/domain.rb
@@ -3,7 +3,7 @@ module Headlines
     validates :name, presence: true
 
     has_many :scans
-    has_one :scan, -> { order("headlines_scans.id DESC") }
+    has_one :scan, -> { order(id: :desc) }
     has_many :domains_categories, foreign_key: :domain_name, primary_key: :name
     has_many :categories, through: :domains_categories
 

--- a/app/models/headlines/domain.rb
+++ b/app/models/headlines/domain.rb
@@ -3,13 +3,13 @@ module Headlines
     validates :name, presence: true
 
     has_many :scans
-    has_one :scan, -> { order(id: :desc) }
+    belongs_to :last_scan, class_name: "Scan"
     has_many :domains_categories, foreign_key: :domain_name, primary_key: :name
     has_many :categories, through: :domains_categories
 
     delegate :categories, to: :data_alexa, prefix: true
-    delegate :headers, to: :scan, prefix: true
-    delegate :score, :http_score, :csp_score, to: :scan
+    delegate :headers, to: :last_scan, prefix: true
+    delegate :score, :http_score, :csp_score, to: :last_scan
 
     def data_alexa=(value)
       self[:data_alexa] = value

--- a/app/query_objects/headlines/domains_in_category.rb
+++ b/app/query_objects/headlines/domains_in_category.rb
@@ -7,7 +7,7 @@ module Headlines
       @category = category
     end
 
-    delegate :count, :limit, :includes, :joins, :order, to: :all
+    delegate :count, :limit, :includes, :joins, :offset, :find, :order, to: :all
 
     def all
       Domain.where("headlines_domains.parent_category_ids && ARRAY[?]", category.id)

--- a/app/query_objects/headlines/filtered_domains.rb
+++ b/app/query_objects/headlines/filtered_domains.rb
@@ -29,13 +29,13 @@ module Headlines
     def headers_filtered_domains(domains, headers: nil)
       return domains unless headers
 
-      domains.joins(:scans).where(headers.map { |i| "((headlines_scans.results -> '#{i}')::int > 0)" }.join("AND"))
+      domains.where(headers.map { |i| "((headlines_scans.results -> '#{i}')::int > 0)" }.join("AND"))
     end
 
     def rating_filtered_domains(domains, ratings: nil)
       return domains unless ratings
 
-      domains.joins(:scans).where(headlines_scans: { score: ratings })
+      domains.where(headlines_scans: { score: ratings })
     end
 
     def country_code

--- a/app/serializers/headlines/domain_scan_serializer.rb
+++ b/app/serializers/headlines/domain_scan_serializer.rb
@@ -7,11 +7,11 @@ module Headlines
     private
 
     def http_headers
-      object.scan_headers[0..-2]
+      object.last_scan_headers[0..-2]
     end
 
     def csp_header
-      object.scan_headers.last
+      object.last_scan_headers.last
     end
 
     def category

--- a/app/serializers/headlines/domain_scan_serializer.rb
+++ b/app/serializers/headlines/domain_scan_serializer.rb
@@ -17,9 +17,5 @@ module Headlines
     def category
       options[:category]
     end
-
-    def domains
-      options[:domains] || []
-    end
   end
 end

--- a/app/serializers/headlines/domain_serializer.rb
+++ b/app/serializers/headlines/domain_serializer.rb
@@ -13,7 +13,7 @@ module Headlines
     end
 
     def last_scan_date
-      object.scan.created_at
+      object.last_scan.created_at
     end
   end
 end

--- a/assets/javascripts/discourse/controllers/headlines-categories-show.js.es6
+++ b/assets/javascripts/discourse/controllers/headlines-categories-show.js.es6
@@ -77,7 +77,7 @@ export default Em.Controller.extend(DomainNameFilter, {
 
     this.setProperties({ noResults: false, loading: true });
 
-    return Discourse.ajax(Discourse.getURL("/headlines/categories/" + model.id + this.searchParams())).then((data) => {
+    return Discourse.ajax(Discourse.getURL("/projects/security-headers/categories/" + model.id + this.searchParams())).then((data) => {
       if (data.domains.length === 0) {
         model.set("allLoaded", true);
       }

--- a/assets/javascripts/discourse/headlines-route-map.js.es6
+++ b/assets/javascripts/discourse/headlines-route-map.js.es6
@@ -1,5 +1,5 @@
 export default function() {
-  this.resource('headlines', function() {
+  this.resource('headlines', { path: 'projects/security-headers' }, function() {
     this.route('categories', { path: '/' })
     this.route('categories-show', { path: '/categories/:id' });
     this.route('domains', { path: '/categories/:category_id/domains/:id' });

--- a/assets/javascripts/discourse/routes/headlines-categories-show.js.es6
+++ b/assets/javascripts/discourse/routes/headlines-categories-show.js.es6
@@ -17,6 +17,11 @@ export default Discourse.Route.extend({
     return PreloadStore.getAndRemove('category', fetchModel(params.id, query)).then(wrapModel);
   },
 
+  setupController(controller, model) {
+    controller.set('model', model);
+    this.controllerFor('application').set('showFooter', true);
+  },
+
   actions: {
     willTransition() {
       this.set('controller.domainNameSearch', '');

--- a/assets/javascripts/discourse/routes/headlines-categories-show.js.es6
+++ b/assets/javascripts/discourse/routes/headlines-categories-show.js.es6
@@ -1,7 +1,7 @@
 import Category from '../models/category'
 
 function fetchModel(category_id, query) {
-  return () => { return Discourse.ajax(Discourse.getURL("/headlines/categories/" + category_id + "?" + query)); };
+  return () => { return Discourse.ajax(Discourse.getURL("/projects/security-headers/categories/" + category_id + "?" + query)); };
 }
 
 function wrapModel(model) {

--- a/assets/javascripts/discourse/routes/headlines-categories.js.es6
+++ b/assets/javascripts/discourse/routes/headlines-categories.js.es6
@@ -1,7 +1,7 @@
 import Category from '../models/category'
 
 function fetchModels(query) {
-  return () => { return Discourse.ajax(Discourse.getURL("/headlines/categories?" + query)); };
+  return () => { return Discourse.ajax(Discourse.getURL("/projects/security-headers/categories?" + query)); };
 }
 
 function wrapInModels(models) {

--- a/assets/javascripts/discourse/routes/headlines-categories.js.es6
+++ b/assets/javascripts/discourse/routes/headlines-categories.js.es6
@@ -18,5 +18,10 @@ export default Discourse.Route.extend({
         query = headlinesController.get('countryFilter') + headlinesController.get('headerFilter');
 
     return PreloadStore.getAndRemove('categories', fetchModels(query)).then(wrapInModels);
+  },
+
+  setupController(controller, model) {
+    controller.set('model', model);
+    this.controllerFor('application').set('showFooter', true);
   }
 })

--- a/assets/javascripts/discourse/routes/headlines-domains.js.es6
+++ b/assets/javascripts/discourse/routes/headlines-domains.js.es6
@@ -26,5 +26,10 @@ function wrapDomain(domain) {
 export default Discourse.Route.extend({
   model(params) {
     return PreloadStore.getAndRemove('domain_scan', fetchModel(params.category_id, params.id)).then(wrapDomain);
+  },
+
+  setupController(controller, model) {
+    controller.set('model', model);
+    this.controllerFor('application').set('showFooter', true);
   }
 })

--- a/assets/javascripts/discourse/routes/headlines-domains.js.es6
+++ b/assets/javascripts/discourse/routes/headlines-domains.js.es6
@@ -5,7 +5,7 @@ import CspHeader from '../models/csp-header'
 
 function fetchModel(category_id, domain_id) {
   return () => {
-    return Discourse.ajax('/headlines/categories/' + category_id + '/domains/' + domain_id);
+    return Discourse.ajax('/projects/security-headers/categories/' + category_id + '/domains/' + domain_id);
   };
 }
 

--- a/assets/javascripts/discourse/routes/headlines.js.es6
+++ b/assets/javascripts/discourse/routes/headlines.js.es6
@@ -1,5 +1,9 @@
 import Spinner from '../mixins/headlines-conditional-spinner'
 
 export default Discourse.Route.extend(Spinner, {
-  beforeModel() { return this.redirectIfLoginRequired(); }
+  beforeModel() { return this.redirectIfLoginRequired(); },
+
+  setupController(controller, model) {
+    this.controllerFor('application').set('showFooter', true);
+  }
 })

--- a/assets/javascripts/discourse/routes/scans.js.es6
+++ b/assets/javascripts/discourse/routes/scans.js.es6
@@ -17,5 +17,10 @@ export default Discourse.Route.extend({
 
   model(params) {
     return PreloadStore.getAndRemove('domain_scan', scanDomain(params.url)).then(wrapDomain);
+  },
+
+  setupController(controller, model) {
+    controller.set('model', model);
+    this.controllerFor('application').set('showFooter', true);
   }
 })

--- a/assets/javascripts/discourse/routes/scans.js.es6
+++ b/assets/javascripts/discourse/routes/scans.js.es6
@@ -1,7 +1,7 @@
 import Domain from '../models/domain'
 
 function scanDomain(name) {
-  return () => { return Discourse.ajax(Discourse.getURL('/headlines/scans?url=' + name)); };
+  return () => { return Discourse.ajax(Discourse.getURL('/projects/security-headers/scans?url=' + name)); };
 }
 
 function wrapDomain(domain) {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,7 +1,7 @@
 en:
   js:
     headlines:
-      title: "Headlines"
+      title: "Security Headers"
       description:
           Do the sites you visit use the best security practices online?
           <br>

--- a/db/migrate/20150908134102_add_last_scan_to_headlines_domains.rb
+++ b/db/migrate/20150908134102_add_last_scan_to_headlines_domains.rb
@@ -1,0 +1,6 @@
+class AddLastScanToHeadlinesDomains < ActiveRecord::Migration
+  def change
+    add_column :headlines_domains, :last_scan_id, :integer
+    add_index :headlines_domains, :last_scan_id
+  end
+end

--- a/lib/headlines/security_headers/content_security_policy.rb
+++ b/lib/headlines/security_headers/content_security_policy.rb
@@ -27,13 +27,9 @@ module Headlines
         @directives ||= header_directives
         meta_directives.each do |meta_directive|
           directive = @directives.find { |d| d.name == meta_directive.name }
-          if directive
-            directive.in_meta = true
-            directive.sources = directive.sources & meta_directive.sources
-          else
-            @directives.push(meta_directive)
-          end
+          directive ? directive.merge(meta_directive) : @directives.push(meta_directive)
         end
+
         @directives
       end
 

--- a/lib/headlines/security_headers/csp_directive.rb
+++ b/lib/headlines/security_headers/csp_directive.rb
@@ -100,6 +100,11 @@ module Headlines
         name == "sandbox" && in_meta
       end
 
+      def merge(directive)
+        self.in_meta = in_meta || directive.in_meta
+        self.sources = sources & directive.sources
+      end
+
       private
 
       def in_list?(name)

--- a/lib/tasks/scan_domains.rake
+++ b/lib/tasks/scan_domains.rake
@@ -35,13 +35,20 @@ namespace :headlines do
     result = Headlines::AnalyzeDomainHeaders.call(url: domain.name)
 
     if result.success?
-      domain.scans.create!(headers: result.params,
-                           results: result.scan_results,
-                           score: result.score,
-                           http_score: result.http_score,
-                           csp_score: result.csp_score)
+      domain.build_last_scan(scan_params(result).merge(domain_id: domain.id))
+      domain.save!
     end
 
     result
+  end
+
+  def scan_params(result)
+    {
+      headers: result.params,
+      results: result.scan_results,
+      score: result.score,
+      http_score: result.http_score,
+      csp_score: result.csp_score
+    }
   end
 end

--- a/lib/tasks/scan_domains.rake
+++ b/lib/tasks/scan_domains.rake
@@ -43,12 +43,6 @@ namespace :headlines do
   end
 
   def scan_params(result)
-    {
-      headers: result.params,
-      results: result.scan_results,
-      score: result.score,
-      http_score: result.http_score,
-      csp_score: result.csp_score
-    }
+    result[:params].slice(:headers, :results, :score, :http_score, :csp_score)
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # name: headlines
 # about: Security vulnerabilities scanner
 # version: 0.0.1
-# author: Securonauts
+# author: SourceClear
 
 gem("interactor", "3.1.0")
 gem("interactor-rails", "2.0.1", require_name: "interactor/rails")
@@ -18,5 +18,5 @@ register_asset("stylesheets/views/headlines.css.scss")
 require(File.expand_path("../lib/headlines", __FILE__))
 
 Discourse::Application.routes.append do
-  mount Headlines::Engine, at: "/headlines"
+  mount Headlines::Engine, at: "/projects/security-headers"
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,49 +11,51 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150824151647) do
+ActiveRecord::Schema.define(version: 20150908134102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "hstore"
 
-  create_table "headlines_categories", force: :cascade do |t|
-    t.string   "title",       default: "",                    null: false
-    t.string   "topic",       default: "",                    null: false
-    t.datetime "created_at",  default: '2015-07-06 16:45:58', null: false
-    t.datetime "updated_at",  default: '2015-07-06 16:45:58', null: false
+  create_table "headlines_categories", force: true do |t|
+    t.string   "title",       limit: nil, default: "",                    null: false
+    t.string   "topic",       limit: nil, default: "",                    null: false
+    t.datetime "created_at",              default: '2015-07-06 16:45:58', null: false
+    t.datetime "updated_at",              default: '2015-07-06 16:45:58', null: false
     t.integer  "category_id"
-    t.text     "description", default: ""
-    t.integer  "parents",     default: [],                    null: false, array: true
+    t.text     "description",             default: ""
+    t.integer  "parents",                 default: [],                    null: false, array: true
   end
 
   add_index "headlines_categories", ["category_id"], name: "index_headlines_categories_on_category_id", using: :btree
   add_index "headlines_categories", ["parents"], name: "index_headlines_categories_on_parents", using: :gin
 
-  create_table "headlines_domains", force: :cascade do |t|
-    t.string   "name",                default: "", null: false
-    t.integer  "rank",                default: 0,  null: false
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
-    t.string   "country_code",        default: "", null: false
+  create_table "headlines_domains", force: true do |t|
+    t.string   "name",                limit: nil, default: "", null: false
+    t.integer  "rank",                            default: 0,  null: false
+    t.datetime "created_at",                                   null: false
+    t.datetime "updated_at",                                   null: false
+    t.string   "country_code",        limit: nil, default: "", null: false
     t.xml      "data_alexa"
-    t.integer  "parent_category_ids", default: [], null: false, array: true
+    t.integer  "parent_category_ids",             default: [], null: false, array: true
+    t.integer  "last_scan_id"
   end
 
+  add_index "headlines_domains", ["last_scan_id"], name: "index_headlines_domains_on_last_scan_id", using: :btree
   add_index "headlines_domains", ["name"], name: "index_headlines_domains_on_name", unique: true, using: :btree
   add_index "headlines_domains", ["parent_category_ids"], name: "index_headlines_domains_on_parent_category_ids", using: :gin
 
-  create_table "headlines_domains_categories", force: :cascade do |t|
+  create_table "headlines_domains_categories", force: true do |t|
     t.integer  "category_id"
-    t.datetime "created_at",  default: '2015-07-06 16:45:58', null: false
-    t.datetime "updated_at",  default: '2015-07-06 16:45:58', null: false
-    t.string   "domain_name"
+    t.datetime "created_at",              default: '2015-07-06 16:45:58', null: false
+    t.datetime "updated_at",              default: '2015-07-06 16:45:58', null: false
+    t.string   "domain_name", limit: nil
   end
 
   add_index "headlines_domains_categories", ["category_id"], name: "index_headlines_domains_categories_on_category_id", using: :btree
   add_index "headlines_domains_categories", ["domain_name"], name: "index_headlines_domains_categories_on_domain_name", using: :btree
 
-  create_table "headlines_scans", force: :cascade do |t|
+  create_table "headlines_scans", force: true do |t|
     t.json     "headers",    default: {}, null: false
     t.hstore   "results",    default: {}, null: false
     t.integer  "domain_id"

--- a/spec/interactors/headlines/generate_results_spec.rb
+++ b/spec/interactors/headlines/generate_results_spec.rb
@@ -12,23 +12,29 @@ module Headlines
 
         it { is_expected.to be_a_success }
 
-        its(:scan_results) { is_expected.to be_present }
-        its("scan_results.size") { is_expected.to eq(2)  }
-        its(:params) { is_expected.to be_present }
-        its("params.size") { is_expected.to eq 2 }
+        it "return hash with parameters" do
+          expect(context.params).to be_present
+          expect(context.params.size).to eq(7)
+        end
       end
 
       describe "returns properly headers score values" do
-        subject(:scan_results) { described_class.call(headers: headers).scan_results }
+        subject(:scan_results) { described_class.call(headers: headers).params[:scan_results] }
 
-        its(["x-xss-protection"]) { is_expected.to eq(2) }
-        its(["x-frame-options"]) { is_expected.to eq(2) }
+        it "returns scores for given headers" do
+          expect(scan_results["x-xss-protection"]).to eq(2)
+          expect(scan_results["x-frame-options"]).to eq(2)
+        end
       end
 
       describe "calculates domain score" do
-        subject(:score) { described_class.call(headers: headers).score }
+        subject(:params) { described_class.call(headers: headers).params }
 
-        it { is_expected.to eq(1) }
+        it "returns domain scores" do
+          expect(params[:http_score]).to eq(1)
+          expect(params[:csp_score]).to eq(0)
+          expect(params[:score]).to eq(1)
+        end
       end
     end
   end

--- a/spec/lib/headlines/security_headers/content_security_policy_http_protocol_rules_spec.rb
+++ b/spec/lib/headlines/security_headers/content_security_policy_http_protocol_rules_spec.rb
@@ -1,0 +1,83 @@
+module Headlines
+  module SecurityHeaders
+    describe ContentSecurityPolicy, "http protocol rules" do
+      let(:headers) { { "content-security-policy" => value } }
+      let(:url) { "example.com" }
+      let(:site_setting) { OpenStruct.new(whitelisted_domains: "facebook.com|google.com") }
+
+      before do
+        stub_const("Headlines::SecurityHeaders::CspDirective::SiteSetting", site_setting)
+      end
+
+      describe "#score" do
+        let(:body) { open_fixture("csp/empty_page.html").read }
+
+        subject(:score) { described_class.new(headers, body, url).score }
+
+        context "with http: source" do
+          let(:value) { "style-src http:;" }
+
+          it { is_expected.to eq(-3) }
+        end
+
+        context "with explicit declaration" do
+          let(:value) { "default-src 'self'; style-src http://example.com;" }
+
+          it { is_expected.to eq(1) }
+        end
+
+        context "with domain without protocol declaration" do
+          let(:value) { "default-src 'self'; style-src example.com;" }
+
+          it { is_expected.to eq(1) }
+        end
+
+        context "with domain starts with *" do
+          context "without any protocol declaration" do
+            let(:value) { "default-src 'self'; style-src */example.com" }
+
+            it { is_expected.to eq(1) }
+          end
+
+          context "with http protocol declaration" do
+            let(:value) { "default-src 'self'; style-src http: */example.com" }
+
+            it { is_expected.to eq(1) }
+          end
+
+          context "with https protocol declaration" do
+            let(:value) { "default-src 'self'; style-src https: */example.com" }
+
+            it { is_expected.to eq(2) }
+          end
+
+          context "with http and https protocol declaration" do
+            let(:value) { "default-src 'self'; style-src http: https: */example.com" }
+
+            it { is_expected.to eq(1) }
+          end
+        end
+
+        context "with potentially unsecure host" do
+          context "with whitelist domains" do
+            let(:value) { "default-src 'self' https://google.com;" }
+
+            it { is_expected.to eq(-2) }
+          end
+
+          context "with subdomains" do
+            let(:value) { "default-src '*'; script-src https://subdomain.example.com;" }
+
+            it { is_expected.to eq(-4) }
+          end
+
+          context "with unsecure domains" do
+            let(:value) { "default-src 'self'; style-src https://unsecurehost.com;" }
+
+            it { is_expected.to eq(2) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/headlines/security_headers/content_security_policy_in_meta_spec.rb
+++ b/spec/lib/headlines/security_headers/content_security_policy_in_meta_spec.rb
@@ -1,0 +1,44 @@
+module Headlines
+  module SecurityHeaders
+    describe ContentSecurityPolicy, "in meta tags" do
+      let(:headers) { { "content-security-policy" => value } }
+      let(:url) { "example.com" }
+      let(:site_setting) { OpenStruct.new(whitelisted_domains: "facebook.com|google.com") }
+
+      before do
+        stub_const("Headlines::SecurityHeaders::CspDirective::SiteSetting", site_setting)
+      end
+
+      describe "#score" do
+        let(:body) { open_fixture("csp/csp-in-meta.html").read }
+
+        subject(:score) { described_class.new(headers, body, url).score }
+
+        context "with empty header" do
+          let(:value) { "" }
+
+          it { is_expected.to eq(0) }
+        end
+
+        context "with valid header value" do
+          let(:value) { "script-src http:;" }
+
+          it { is_expected.to eq(-1) }
+        end
+
+        context "with invalid header value" do
+          let(:value) { "invalid-directive 'self';" }
+
+          it { is_expected.to eq(0) }
+        end
+
+        context "with Link header" do
+          let(:headers) { { "content-security-policy" => value, "link" => "some header value" } }
+          let(:value) { "script-src http:;" }
+
+          it { is_expected.to eq(-3) }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/headlines/security_headers/content_security_policy_non_restrictive_rules_spec.rb
+++ b/spec/lib/headlines/security_headers/content_security_policy_non_restrictive_rules_spec.rb
@@ -1,0 +1,93 @@
+module Headlines
+  module SecurityHeaders
+    describe ContentSecurityPolicy, "non restrictive rules" do
+      let(:headers) { { "content-security-policy" => value } }
+      let(:url) { "example.com" }
+      let(:site_setting) { OpenStruct.new(whitelisted_domains: "facebook.com|google.com") }
+
+      before do
+        stub_const("Headlines::SecurityHeaders::CspDirective::SiteSetting", site_setting)
+      end
+
+      describe "#score" do
+        let(:body) { open_fixture("csp/empty_page.html").read }
+
+        subject(:score) { described_class.new(headers, body, url).score }
+
+        context "with default-src equal '*'" do
+          let(:value) { "default-src '*';" }
+
+          it { is_expected.to eq(-4) }
+        end
+
+        context "with script-src equal '*'" do
+          let(:value) { "script-src '*';" }
+
+          it { is_expected.to eq(-4) }
+        end
+
+        context "with style-src equal '*'" do
+          let(:value) { "style-src '*';" }
+
+          it { is_expected.to eq(-4) }
+        end
+
+        context "with 'unsafe-eval'" do
+          context "with 'nonce'" do
+            let(:value) { "default-src 'unsafe-eval' 'nonce';" }
+
+            it { is_expected.to eq(-2) }
+          end
+
+          context "without 'nonce'" do
+            context "with default-src directive" do
+              let(:value) { "default-src 'unsafe-eval';" }
+
+              it { is_expected.to eq(-4) }
+            end
+
+            context "with script-src directive" do
+              let(:value) { "script-src 'unsafe-eval';" }
+
+              it { is_expected.to eq(-4) }
+            end
+
+            context "with style-src directive" do
+              let(:value) { "style-src 'unsafe-eval';" }
+
+              it { is_expected.to eq(-4) }
+            end
+          end
+        end
+
+        context "with 'unsafe-inline'" do
+          context "with 'nonce'" do
+            let(:value) { "default-src 'unsafe-inline' 'nonce';" }
+
+            it { is_expected.to eq(-2) }
+          end
+
+          context "without 'nonce'" do
+            context "with default-src directive" do
+              let(:value) { "default-src 'unsafe-inline';" }
+
+              it { is_expected.to eq(-4) }
+            end
+
+            context "with script-src directive" do
+              let(:value) { "script-src 'unsafe-inline';" }
+
+              it { is_expected.to eq(-4) }
+            end
+
+            context "with style-src directive" do
+              let(:value) { "style-src 'unsafe-inline';" }
+
+              it { is_expected.to eq(-4) }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/headlines/security_headers/content_security_policy_report_only_in_meta_spec.rb
+++ b/spec/lib/headlines/security_headers/content_security_policy_report_only_in_meta_spec.rb
@@ -1,0 +1,37 @@
+module Headlines
+  module SecurityHeaders
+    describe ContentSecurityPolicy, "Report-Only header in meta tags" do
+      let(:headers) { { "content-security-policy" => value } }
+      let(:url) { "example.com" }
+      let(:site_setting) { OpenStruct.new(whitelisted_domains: "facebook.com|google.com") }
+
+      before do
+        stub_const("Headlines::SecurityHeaders::CspDirective::SiteSetting", site_setting)
+      end
+
+      describe "#score" do
+        let(:body) { open_fixture("csp/report-only-in-meta.html").read }
+
+        subject(:score) { described_class.new(headers, body, url).score }
+
+        context "with empty header" do
+          let(:value) { "" }
+
+          it { is_expected.to eq(-15) }
+        end
+
+        context "with valid header value" do
+          let(:value) { "default-src 'self';" }
+
+          it { is_expected.to eq(1) }
+        end
+
+        context "with invalid header value" do
+          let(:value) { "invalid-directive 'self';" }
+
+          it { is_expected.to eq(-15) }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/headlines/security_headers/content_security_policy_restrictive_rules_spec.rb
+++ b/spec/lib/headlines/security_headers/content_security_policy_restrictive_rules_spec.rb
@@ -1,0 +1,101 @@
+module Headlines
+  module SecurityHeaders
+    describe ContentSecurityPolicy, "restrictive rules" do
+      let(:headers) { { "content-security-policy" => value } }
+      let(:url) { "example.com" }
+      let(:site_setting) { OpenStruct.new(whitelisted_domains: "facebook.com|google.com") }
+
+      before do
+        stub_const("Headlines::SecurityHeaders::CspDirective::SiteSetting", site_setting)
+      end
+
+      describe "#score" do
+        let(:body) { open_fixture("csp/empty_page.html").read }
+
+        subject(:score) { described_class.new(headers, body, url).score }
+
+        context "with at least one valid directive" do
+          let(:value) { "default-src 'self'; invalid-directive 'self';" }
+
+          it { is_expected.to eq(2) }
+        end
+
+        context "with default-src equal 'none'" do
+          let(:value) { "default-src 'none';" }
+
+          it { is_expected.to eq(2) }
+        end
+
+        context "with default-src equal 'self'" do
+          let(:value) { "default-src 'self';" }
+
+          it { is_expected.to eq(2) }
+        end
+
+        context "with report-uri directive" do
+          let(:value) { "default-src 'self'; report-uri https://example.com" }
+
+          it { is_expected.to eq(6) }
+        end
+
+        context "with Content-Security-Policy-Report-Only header" do
+          let(:value) { "default-src 'self';" }
+
+          context "with identical" do
+            let(:headers) do
+              {
+                "content-security-policy" => value,
+                "content-security-policy-report-only" => value
+              }
+            end
+
+            it { is_expected.to eq(6) }
+          end
+
+          context "with different" do
+            let(:headers) do
+              {
+                "content-security-policy" => value,
+                "content-security-policy-report-only" => "different-directive 'self';"
+              }
+            end
+
+            context "without report-uri directive" do
+              it { is_expected.to eq(2) }
+            end
+
+            context "with report-uri directive" do
+              let(:value) { "default-src 'self'; report-uri https://example.com" }
+
+              it { is_expected.to eq(6) }
+            end
+          end
+        end
+
+        context "with script-src equal 'self'" do
+          let(:value) { "script-src 'self';" }
+
+          it { is_expected.to eq(-1) }
+        end
+
+        context "with style-src equal 'self'" do
+          let(:value) { "style-src 'self';" }
+
+          it { is_expected.to eq(-1) }
+        end
+
+        context "with script-src equal 'nonce-<some value>'" do
+          let(:value) { "script-src 'nonce-Nc3n83cnSAd3wc3Sasdfn939hc3';" }
+
+          it { is_expected.to eq(0) }
+        end
+
+        context "with style-src equal 'nonce-<some value>'" do
+          let(:value) { "style-src 'nonce-Nc3n83cnSAd3wc3Sasdfn939hc3';" }
+
+          it { is_expected.to eq(0) }
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/headlines/security_headers/content_security_policy_spec.rb
+++ b/spec/lib/headlines/security_headers/content_security_policy_spec.rb
@@ -10,315 +10,40 @@ module Headlines
       end
 
       describe "#score" do
+        let(:body) { open_fixture("csp/empty_page.html").read }
+
         subject(:score) { described_class.new(headers, body, url).score }
 
-        describe "without header and csp in meta" do
+        context "without header and csp in meta" do
           let(:body) { "" }
           let(:value) { nil }
 
           it { is_expected.to eq(-15) }
         end
 
-        describe "with only header" do
-          let(:body) { open_fixture("csp/empty_page.html").read }
+        context "with blank value" do
+          let(:value) { "" }
 
-          context "with blank value" do
-            let(:value) { "" }
-
-            it { is_expected.to eq(-15) }
-          end
-
-          context "without valid directives" do
-            let(:value) { "invalid-directive 'self';" }
-
-            it { is_expected.to eq(-15) }
-          end
-
-          context "with at least one valid directive" do
-            let(:value) { "default-src 'self'; invalid-directive 'self';" }
-
-            it { is_expected.to eq(2) }
-          end
-
-          context "with invalid directive value" do
-            context "with 'none' parameter" do
-              let(:value) { "default-src 'self' 'none'; connect-src 'self';" }
-
-              it { is_expected.to eq(-15) }
-            end
-
-            context "with '*' parameter" do
-              let(:value) { "default-src 'self'; connect-src '*' 'self';" }
-
-              it { is_expected.to eq(-15) }
-            end
-          end
-
-          context "with default-src equal 'none'" do
-            let(:value) { "default-src 'none';" }
-
-            it { is_expected.to eq(2) }
-          end
-
-          context "with default-src equal 'self'" do
-            let(:value) { "default-src 'self';" }
-
-            it { is_expected.to eq(2) }
-          end
-
-          context "with default-src equal '*'" do
-            let(:value) { "default-src '*';" }
-
-            it { is_expected.to eq(-4) }
-          end
-
-          context "with http: value" do
-            let(:value) { "style-src http:;" }
-
-            it { is_expected.to eq(-3) }
-          end
-
-          context "with report-uri directive" do
-            let(:value) { "default-src 'self'; report-uri https://example.com" }
-
-            it { is_expected.to eq(6) }
-          end
-
-          context "with Content-Security-Policy-Report-Only header" do
-            let(:value) { "default-src 'self';" }
-
-            context "with identical" do
-              let(:headers) do
-                {
-                  "content-security-policy" => value,
-                  "content-security-policy-report-only" => value
-                }
-              end
-
-              it { is_expected.to eq(6) }
-            end
-
-            context "with different" do
-              let(:headers) do
-                {
-                  "content-security-policy" => value,
-                  "content-security-policy-report-only" => "different-directive 'self';"
-                }
-              end
-
-              context "without report-uri directive" do
-                it { is_expected.to eq(2) }
-              end
-
-              context "with report-uri directive" do
-                let(:value) { "default-src 'self'; report-uri https://example.com" }
-
-                it { is_expected.to eq(6) }
-              end
-            end
-          end
-
-          context "with script-src equal '*'" do
-            let(:value) { "script-src '*';" }
-
-            it { is_expected.to eq(-4) }
-          end
-
-          context "with style-src equal '*'" do
-            let(:value) { "style-src '*';" }
-
-            it { is_expected.to eq(-4) }
-          end
-
-          context "with script-src equal 'self'" do
-            let(:value) { "script-src 'self';" }
-
-            it { is_expected.to eq(-1) }
-          end
-
-          context "with style-src equal 'self'" do
-            let(:value) { "style-src 'self';" }
-
-            it { is_expected.to eq(-1) }
-          end
-
-          context "with script-src equal 'nonce-<some value>'" do
-            let(:value) { "script-src 'nonce-Nc3n83cnSAd3wc3Sasdfn939hc3';" }
-
-            it { is_expected.to eq(0) }
-          end
-
-          context "with style-src equal 'nonce-<some value>'" do
-            let(:value) { "style-src 'nonce-Nc3n83cnSAd3wc3Sasdfn939hc3';" }
-
-            it { is_expected.to eq(0) }
-          end
-
-          context "with 'unsafe-eval'" do
-            context "with 'nonce'" do
-              let(:value) { "default-src 'unsafe-eval' 'nonce';" }
-
-              it { is_expected.to eq(-2) }
-            end
-
-            context "without 'nonce'" do
-              context "with default-src directive" do
-                let(:value) { "default-src 'unsafe-eval';" }
-
-                it { is_expected.to eq(-4) }
-              end
-
-              context "with script-src directive" do
-                let(:value) { "script-src 'unsafe-eval';" }
-
-                it { is_expected.to eq(-4) }
-              end
-
-              context "with style-src directive" do
-                let(:value) { "style-src 'unsafe-eval';" }
-
-                it { is_expected.to eq(-4) }
-              end
-            end
-          end
-
-          context "with 'unsafe-inline' without 'nonce'" do
-            context "with 'nonce'" do
-              let(:value) { "default-src 'unsafe-inline' 'nonce';" }
-
-              it { is_expected.to eq(-2) }
-            end
-
-            context "without 'nonce'" do
-              context "with default-src directive" do
-                let(:value) { "default-src 'unsafe-inline';" }
-
-                it { is_expected.to eq(-4) }
-              end
-
-              context "with script-src directive" do
-                let(:value) { "script-src 'unsafe-inline';" }
-
-                it { is_expected.to eq(-4) }
-              end
-
-              context "with style-src directive" do
-                let(:value) { "style-src 'unsafe-inline';" }
-
-                it { is_expected.to eq(-4) }
-              end
-            end
-          end
-
-          context "with http protocol" do
-            context "with explicit declaration" do
-              let(:value) { "default-src 'self'; style-src http://example.com;" }
-
-              it { is_expected.to eq(1) }
-            end
-
-            context "with domain without protocol declaration" do
-              let(:value) { "default-src 'self'; style-src example.com;" }
-
-              it { is_expected.to eq(1) }
-            end
-
-            context "with domain starts with *" do
-              context "without any protocol declaration" do
-                let(:value) { "default-src 'self'; style-src */example.com" }
-
-                it { is_expected.to eq(1) }
-              end
-
-              context "with http protocol declaration" do
-                let(:value) { "default-src 'self'; style-src http: */example.com" }
-
-                it { is_expected.to eq(1) }
-              end
-
-              context "with https protocol declaration" do
-                let(:value) { "default-src 'self'; style-src https: */example.com" }
-
-                it { is_expected.to eq(2) }
-              end
-
-              context "with http and https protocol declaration" do
-                let(:value) { "default-src 'self'; style-src http: https: */example.com" }
-
-                it { is_expected.to eq(1) }
-              end
-            end
-          end
-
-          context "with potentially unsecure host" do
-            context "with whitelist domains" do
-              let(:value) { "default-src 'self' https://google.com;" }
-
-              it { is_expected.to eq(-2) }
-            end
-
-            context "with subdomains" do
-              let(:value) { "default-src '*'; script-src https://subdomain.example.com;" }
-
-              it { is_expected.to eq(-4) }
-            end
-
-            context "with unsecure domains" do
-              let(:value) { "default-src 'self'; style-src https://unsecurehost.com;" }
-
-              it { is_expected.to eq(2) }
-            end
-          end
+          it { is_expected.to eq(-15) }
         end
 
-        context "with Report-Only in meta" do
-          let(:body) { open_fixture("csp/report-only-in-meta.html").read }
+        context "without valid directives" do
+          let(:value) { "invalid-directive 'self';" }
 
-          context "with empty header" do
-            let(:value) { "" }
-
-            it { is_expected.to eq(-15) }
-          end
-
-          context "with valid header value" do
-            let(:value) { "default-src 'self';" }
-
-            it { is_expected.to eq(1) }
-          end
-
-          context "with invalid header value" do
-            let(:value) { "invalid-directive 'self';" }
-
-            it { is_expected.to eq(-15) }
-          end
+          it { is_expected.to eq(-15) }
         end
 
-        context "with csp in meta tags" do
-          let(:body) { open_fixture("csp/csp-in-meta.html").read }
+        context "with invalid directive value" do
+          context "with 'none' parameter" do
+            let(:value) { "default-src 'self' 'none'; connect-src 'self';" }
 
-          context "with empty header" do
-            let(:value) { "" }
-
-            it { is_expected.to eq(0) }
+            it { is_expected.to eq(-15) }
           end
 
-          context "with valid header value" do
-            let(:value) { "script-src http:;" }
+          context "with '*' parameter" do
+            let(:value) { "default-src 'self'; connect-src '*' 'self';" }
 
-            it { is_expected.to eq(-1) }
-          end
-
-          context "with invalid header value" do
-            let(:value) { "invalid-directive 'self';" }
-
-            it { is_expected.to eq(0) }
-          end
-
-          context "with Link header" do
-            let(:headers) { { "content-security-policy" => value, "link" => "some header value" } }
-            let(:value) { "script-src http:;" }
-
-            it { is_expected.to eq(-3) }
+            it { is_expected.to eq(-15) }
           end
         end
       end

--- a/spec/query_objects/headlines/filtered_domains_spec.rb
+++ b/spec/query_objects/headlines/filtered_domains_spec.rb
@@ -7,7 +7,7 @@ module Headlines
     let!(:scan) { create :scan, score: 3 }
     let!(:searchable_domain) { create(:domain, country_code: "AU", scans: [scan]) }
 
-    subject(:filtered_domains) { described_class.new(domains: Domain.all, filter_options: filter_options) }
+    subject(:filtered_domains) { described_class.new(domains: Domain.joins(:scans), filter_options: filter_options) }
 
     describe "#call" do
       context "without any filter" do


### PR DESCRIPTION
CHANGELOG:
- Search only in last domain scan results if domain has many scans
- Show footer on all pages
- Change routes from /headlines to /projects/security-headers
